### PR TITLE
fix: when sending snapshot, snapshot.Next iterates forever until raft error

### DIFF
--- a/transport_replicate.go
+++ b/transport_replicate.go
@@ -151,22 +151,25 @@ func (t *replicateTransport) sendSnapshot(m *proto.Message, rs *snapshotStatus) 
 
 		default:
 			data, err = m.Snapshot.Next()
+
+			// to prevent err from being overrided
+			var innerError error
 			if len(data) > 0 {
 				// write block size
 				binary.BigEndian.PutUint32(sizeBuf, uint32(len(data)))
-				if _, err = bufWr.Write(sizeBuf); err == nil {
-					_, err = bufWr.Write(data)
+				if _, innerError = bufWr.Write(sizeBuf); innerError == nil {
+					_, innerError = bufWr.Write(data)
 				}
+			}
+
+			if err == nil {
+				err = innerError
 			}
 		}
 	}
 
 	// write end flag and flush
 	if err != nil && err != io.EOF {
-		return
-	}
-	binary.BigEndian.PutUint32(sizeBuf, 0)
-	if _, err = bufWr.Write(sizeBuf); err != nil {
 		return
 	}
 	if err = bufWr.Flush(); err != nil {


### PR DESCRIPTION
This PR fixes two problems:

1. If snapshot.Next returns io.EOF, the sending loop should be ended
2. Writing zero payload to buffer will cause message decode error