### PR TITLE
check msg magic to avoid invalid memory allocate

### DIFF
--- a/proto/proto.go
+++ b/proto/proto.go
@@ -42,6 +42,10 @@ const (
 	LeaseMsgTimeout
 	ReqCheckQuorum
 	RespCheckQuorum
+
+	MsgTypeEnd
+
+	MsgMagic = 0x5A
 )
 
 const (
@@ -163,6 +167,8 @@ func (t MsgType) String() string {
 		return "ReqCheckQuorum"
 	case 15:
 		return "RespCheckQuorum"
+	case 90:
+		return "MsgMagic"
 	}
 	return "unkown"
 }


### PR DESCRIPTION
Now raft uses data[0:4] as the message size, but data[0:4] can be
any value, if we not check the messages whether they are sended by
raft itself, the memory may be very big.

Signed-off-by: kungf <wings.wyang@gmail.com>